### PR TITLE
Persist container open/closed state at transition time

### DIFF
--- a/ServerCore/java/org/elkoserver/server/context/Item.java
+++ b/ServerCore/java/org/elkoserver/server/context/Item.java
@@ -123,6 +123,17 @@ public class Item extends BasicObject {
         if (isContainer() && !amClosed) {
             amClosed = true;
             markAsChanged();
+            /* Persist the closed flag now rather than leaving it for a
+               shutdown-time flush.  The persisted 'closed' flag gates whether
+               this container's contents are loaded (and thus described to
+               arriving users) at context activation, so a stale value strands
+               the contents invisible after a restart.  Deferring the write
+               also risks losing it entirely on an unclean shutdown, and any
+               application-level checkpoint taken before the flush would
+               persist the old value.  Checkpointing here additionally flushes
+               any still-dirty contents before they are dropped from memory
+               below. */
+            checkpoint();
             for (Item item : contents()) {
                 context().send(Msg.msgDelete(item));
             }
@@ -276,6 +287,14 @@ public class Item extends BasicObject {
         if (isContainer() && amClosed) {
             amClosed = false;
             markAsChanged();
+            /* Persist the open flag now — see closeContainer() for why the
+               'closed' flag must never sit dirty in memory: it controls
+               whether contents are loaded at context activation, so an
+               application checkpoint or unclean shutdown in the window would
+               persist 'closed' for a container everyone sees as open, hiding
+               its contents from every user who arrives after the next
+               activation. */
+            checkpoint();
             myContextor.loadItemContents(this, new ArgRunnable() {
                 public void run(Object obj) {
                     activatePassiveContents("");


### PR DESCRIPTION
Hi Chip — found in the Neohabitat restoration project, live on our production server, and traced down to core.

## The bug

`Item.openContainer()` / `closeContainer()` flip `amClosed` but only `markAsChanged()`, deferring the write of the persisted `closed` flag to a later (typically shutdown-time) checkpoint. That flag is load-bearing at activation: `Contextor` only loads — and therefore only describes to arriving users — the contents of containers whose persisted state is not closed.

Two failure modes:

1. **An application-level checkpoint taken before the deferred flush persists the stale value.** In Neohabitat this happens on every container-open verb (the app checkpoints the object, then calls `openContainer()`), yielding a stored object that is visually open at the application layer but `"closed": true` at the core layer. After the next context activation, every arriving user sees an open container whose contents were never loaded and never described — an open box that is secretly empty, on every client type. We witnessed the desynced object record in the object database and confirmed via wire trace that no contents `make`s are sent to an arriving user.
2. **An unclean shutdown in the window loses the transition outright**, with the same symptom on the next activation.

## The fix

`checkpoint()` the item immediately after flipping `amClosed`, in both transitions. Since `checkpoint()` recurses into contents before writing the item itself, this also flushes any still-dirty contents before `closeContainer()` drops them from memory — previously those pending changes were silently lost.

Open/close transitions are rare, user-initiated operations, so the added object-database write is negligible.

## Field report

Reproduced against a region containing an open box: an arriving user received `make`s for every region object and avatar (pockets included) but none for the box's contents; the stored box record read `"closed": true` alongside the application mod's open state. In-world symptom: GET from an open container fails for anyone who entered after the last activation, until someone closes and re-opens it (which re-runs the container transition and heals the live context).

— Randy (with Claude doing the digging)